### PR TITLE
Make homepage and CV page layouts mobile responsive

### DIFF
--- a/src/components/cv/Education/EducationItem.js
+++ b/src/components/cv/Education/EducationItem.js
@@ -22,18 +22,17 @@ const EducationItem = ({
     // horizontal stack with pictute and text
     <Box padding={0.5}>
       <Stack
-        direction="row"
+        direction={{ xs: 'column-reverse', sm: 'row' }}
         spacing={2}
         marginBottom={2}
-        alignItems="center"
-        divider={<Divider orientation="vertical" flexItem />}
+        alignItems={{ xs: 'flex-start', sm: 'center' }}
+        divider={<Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', sm: 'block' } }} />}
       >
-        <img
+        <Box
+          component="img"
           src={logo}
           alt="Logo"
-          style={{
-            width: "25%",
-          }}
+          sx={{ width: { xs: '50%', sm: '25%' } }}
         />
 
         <Typography variant="h8" sx={{ letterSpacing: 2, width: "100%" }}>

--- a/src/components/cv/Experience/ExperienceItem.js
+++ b/src/components/cv/Experience/ExperienceItem.js
@@ -1,22 +1,22 @@
 import Stack from "@mui/material/Stack";
 import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
 
 function ExperienceHeader({ Workplace, subtitle, logo }) {
   return (
     <Stack
-      direction="row"
+      direction={{ xs: 'column-reverse', sm: 'row' }}
       spacing={2}
       marginBottom={2}
-      alignItems="center"
-      divider={<Divider orientation="vertical" flexItem />}
+      alignItems={{ xs: 'flex-start', sm: 'center' }}
+      divider={<Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', sm: 'block' } }} />}
     >
-      <img
+      <Box
+        component="img"
         src={logo}
         alt="Logo"
-        style={{
-          width: "25%",
-        }}
+        sx={{ width: { xs: '50%', sm: '25%' } }}
       />
       <Stack direction="column" spacing={1}>
         <Typography variant="h5" sx={{ letterSpacing: 2, width: "100%" }}>

--- a/src/components/homepage/IntroBanner.js
+++ b/src/components/homepage/IntroBanner.js
@@ -5,8 +5,15 @@ import AdaCore from './AdaCore';
 
 const Intro = () => {
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', py: 6, px: 7 }}>
-      <Box sx={{ maxWidth: '50%' }}>
+    <Box sx={{
+      display: 'flex',
+      flexDirection: { xs: 'column', md: 'row' },
+      justifyContent: 'space-between',
+      alignItems: { xs: 'center', md: 'flex-start' },
+      py: 6,
+      px: { xs: 2, md: 7 },
+    }}>
+      <Box sx={{ maxWidth: { xs: '100%', md: '50%' } }}>
         <Typography variant="h2" align="left" gutterBottom>
           Hi!
         </Typography>
@@ -14,7 +21,16 @@ const Intro = () => {
           Here, I share my tips, thoughts, setup, and tools.
 
       </Box>
-      <Box component="img" src="/photo.jpg" alt="Zak" sx={{ maxWidth: '45%', height: 'auto' }} />
+      <Box
+        component="img"
+        src="/photo.jpg"
+        alt="Zak"
+        sx={{
+          maxWidth: { xs: '80%', md: '45%' },
+          height: 'auto',
+          mt: { xs: 3, md: 0 },
+        }}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
On mobile phone widths (< 600px), stack images/logos below text instead
of side-by-side. Uses MUI breakpoint responsive values on flexDirection,
alignItems, padding, and widths.

https://claude.ai/code/session_01GeFMKYUVqSYXfZdAvF8QbJ