### PR TITLE
Fix 404 on CV page refresh using spa-github-pages redirect trick

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>My page</title>
+    <script>
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      // This script encodes the path into a query string parameter
+      // so GitHub Pages can serve it, and index.html can restore it.
+      var segmentsToKeep = 0; // root domain (zakaria1193.github.io)
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + segmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(segmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,21 @@
       href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
     />
 
+    <script>
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      // Restores the URL that was encoded by 404.html
+      (function(l) {
+        if (l.search[1] === '/') {
+          var decoded = l.search.slice(1).split('&').map(function(s) {
+            return s.replace(/~and~/g, '&');
+          }).join('?');
+          window.history.replaceState(null, null,
+            l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location));
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
GitHub Pages serves static files only, so refreshing /cv causes a 404
because no file exists at that path. This adds a 404.html that encodes
the requested URL into a query string and redirects to index.html, which
then restores the original URL via history.replaceState before React
Router initializes.

https://claude.ai/code/session_01WuUhES6ZJAKXePeGiT79RY