### PR TITLE
Apply bullet point design improvements to Education section

### DIFF
--- a/src/components/cv/Education/Items/ENSEEIHT.js
+++ b/src/components/cv/Education/Items/ENSEEIHT.js
@@ -1,4 +1,5 @@
-import { EducationItem, EducationDescription } from "../EducationItem";
+import { EducationItem } from "../EducationItem";
+import { BulletList, BulletItem } from "../../Experience/ExperienceItem";
 import enseeiht_logo from "../../../../assets/enseeiht_logo.png";
 
 const ENSEEIHT = () => {
@@ -11,9 +12,9 @@ const ENSEEIHT = () => {
       end="2015"
       location="Toulouse, France"
     >
-      <EducationDescription>
-        Major in electrical and automation engineering.
-      </EducationDescription>
+      <BulletList>
+        <BulletItem>Major in electrical and automation engineering.</BulletItem>
+      </BulletList>
     </EducationItem>
   );
 };

--- a/src/components/cv/Education/Items/GaTech.js
+++ b/src/components/cv/Education/Items/GaTech.js
@@ -1,4 +1,5 @@
-import { EducationItem, EducationDescription } from "../EducationItem";
+import { EducationItem } from "../EducationItem";
+import { BulletList, BulletItem } from "../../Experience/ExperienceItem";
 
 import gatech_logo from "../../../../assets/georgia_tech_extended_logo.png";
 
@@ -12,11 +13,10 @@ const GaTech = () => {
       end="2016"
       location="Atlanta, GA, USA"
     >
-      <EducationDescription>
-        Coursework focused on sensor networks, controls systems and autonomous
-        robotics.
-        <br /> Minor in mechanical engineering.
-      </EducationDescription>
+      <BulletList>
+        <BulletItem>Coursework focused on sensor networks, controls systems and autonomous robotics.</BulletItem>
+        <BulletItem>Minor in mechanical engineering.</BulletItem>
+      </BulletList>
     </EducationItem>
   );
 };


### PR DESCRIPTION
## Summary
- Replace `EducationDescription` (prose with `<br />` breaks) with semantic `BulletList`/`BulletItem` components in both education entries
- Reuses the same components from `ExperienceItem.js` for visual consistency across the entire CV page
- GaTech entry: two separate bullet points (coursework + minor in mechanical engineering)
- ENSEEIHT entry: single bullet point for the major

## Test plan
- [ ] Visit the CV page and verify the Education section bullet points render with `•` markers
- [ ] Confirm visual consistency with the Experience section bullet points
- [ ] Check responsive layout on mobile viewport

https://claude.ai/code/session_017LzvyUULU74DR95YJArPLj